### PR TITLE
Prevent out-of-bounds memory indexing

### DIFF
--- a/Core/chip8.c
+++ b/Core/chip8.c
@@ -612,9 +612,9 @@ static inline void execFX30()
 // FX33: Store BCD representation of VX in memory locations I, I+1, and I+2
 static inline void execFX33()
 {
-    memory.data[cpu.I] = cpu.V[OPCODE_X] / 100;
-    memory.data[cpu.I + 1] = (cpu.V[OPCODE_X] / 10) % 10;
-    memory.data[cpu.I + 2] = cpu.V[OPCODE_X] % 10;
+    memory.data[cpu.I & 0xFFF] = cpu.V[OPCODE_X] / 100;
+    memory.data[(cpu.I + 1) & 0xFFF] = (cpu.V[OPCODE_X] / 10) % 10;
+    memory.data[(cpu.I + 2) & 0xFFF] = cpu.V[OPCODE_X] % 10;
     cpu.PC += 2;
 }
 
@@ -623,7 +623,8 @@ static inline void execFX33()
 // Note: The original implementation also increments I by the number of registers written.
 static inline void execFX55()
 {
-    memcpy(&memory.data[cpu.I], cpu.V, OPCODE_X + 1);
+    for (int i = 0; i <= OPCODE_X; i++)
+        memory.data[(cpu.I + i) & 0xFFF] = cpu.V[i];
 
     if (cpu.compatibility_mode)
         cpu.I += (OPCODE_X + 1);
@@ -636,7 +637,8 @@ static inline void execFX55()
 // Note: The original implementation also increments I by the number of registers read.
 static inline void execFX65()
 {
-    memcpy(cpu.V, &memory.data[cpu.I], OPCODE_X + 1);
+    for (int i = 0; i <= OPCODE_X; i++)
+        cpu.V[i] = memory.data[(cpu.I + i) & 0xFFF];
 
     if (cpu.compatibility_mode)
         cpu.I += (OPCODE_X + 1);


### PR DESCRIPTION
If `I` ends up greater than 0xfff, then the memory array can be indexed out-of-bounds. This is a security vulnerability. A malicious ROM can leverage this to escape the emulator, and execute arbitrary native code on the host system.

Interestingly, the original CHIP-8 interpreter for COSMAC VIP had this same problem, so it is arguably "correct" behaviour - but I think it's potentially unsafe in today's computing landscape. I haven't yet investigated what the effects of out-of-bounds accesses would be on a COSMAC VIP - perhaps either open-bus, or wraparound (due to mirroring), or something else entirely.

I think the simplest and "cheapest" way to fix this is to always mask the memory index with 0xFFF, effectively implementing wraparound - which is what this PR does. I'm not aware of any existing ROMs that this would affect, in any practical sense.